### PR TITLE
Add Client and Vendor UI cards

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -15,7 +15,7 @@ import seedu.address.commons.util.ConfigUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
-import seedu.address.model.AddressBook;
+// import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -73,22 +73,26 @@ public class MainApp extends Application {
      * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        logger.info("Using data file : " + storage.getAddressBookFilePath());
+        // logger.info("Using data file : " + storage.getAddressBookFilePath());
 
-        Optional<ReadOnlyAddressBook> addressBookOptional;
-        ReadOnlyAddressBook initialData;
-        try {
-            addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Creating a new data file " + storage.getAddressBookFilePath()
-                        + " populated with a sample AddressBook.");
-            }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-        } catch (DataLoadingException e) {
-            logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook.");
-            initialData = new AddressBook();
-        }
+        // Optional<ReadOnlyAddressBook> addressBookOptional;
+        // ReadOnlyAddressBook initialData;
+        // try {
+        //     addressBookOptional = storage.readAddressBook();
+        //     if (!addressBookOptional.isPresent()) {
+        //         logger.info("Creating a new data file " + storage.getAddressBookFilePath()
+        //                 + " populated with a sample AddressBook.");
+        //     }
+        //     initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+        // } catch (DataLoadingException e) {
+        //     logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
+        //             + " Will be starting with an empty AddressBook.");
+        //     initialData = new AddressBook();
+        // }
+
+        // always load from sample data since we have not worked on saving/loading
+        ReadOnlyAddressBook initialData = SampleDataUtil.getSampleAddressBook();
+        logger.info(initialData.toString());
 
         return new ModelManager(initialData, userPrefs);
     }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 
 /**
@@ -32,6 +33,8 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    ObservableList<Contact> getFilteredContactList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -69,6 +70,12 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    @Override
+    public ObservableList<Contact> getFilteredContactList() {
+        logger.info(model.getFilteredContactList().toString());
+        return model.getFilteredContactList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -74,7 +74,6 @@ public class LogicManager implements Logic {
 
     @Override
     public ObservableList<Contact> getFilteredContactList() {
-        logger.info(model.getFilteredContactList().toString());
         return model.getFilteredContactList();
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.UniqueContactList;
 import seedu.address.model.person.UniquePersonList;
 
 /**
@@ -26,6 +28,19 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+    }
+
+    private final UniqueContactList contacts;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        contacts = new UniqueContactList();
     }
 
     public AddressBook() {}
@@ -49,12 +64,21 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * TODO
+     */
+    public void setContacts(List<Contact> contacts) {
+        this.contacts.setContacts(contacts);
+    }
+
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setContacts(newData.getContactList());
     }
 
     //// person-level operations
@@ -94,18 +118,31 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * TODO
+     */
+    public void addContact(Contact c) {
+        contacts.add(c);
+    }
+
     //// util methods
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("persons", persons)
+                // .add("persons", persons)
+                .add("contacts", contacts)
                 .toString();
     }
 
     @Override
     public ObservableList<Person> getPersonList() {
         return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Contact> getContactList() {
+        return contacts.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -130,7 +130,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                // .add("persons", persons)
+                .add("persons", persons)
                 .add("contacts", contacts)
                 .toString();
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 
 /**
@@ -78,6 +79,8 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
+
+    ObservableList<Contact> getFilteredContactList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Contact> filteredContacts;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredContacts = new FilteredList<>(this.addressBook.getContactList());
     }
 
     public ModelManager() {
@@ -120,6 +123,11 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return filteredPersons;
+    }
+
+    @Override
+    public ObservableList<Contact> getFilteredContactList() {
+        return filteredContacts;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 
 /**
@@ -14,4 +15,5 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
+    ObservableList<Contact> getContactList();
 }

--- a/src/main/java/seedu/address/model/person/Service.java
+++ b/src/main/java/seedu/address/model/person/Service.java
@@ -11,7 +11,7 @@ public class Service {
     public static final String MESSAGE_CONSTRAINTS =
             "Services should only contain alphanumeric characters and spaces, and it should not be blank";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
-    public final String service;
+    public final String value;
     /**
      * Constructs a {@code Service}.
      *
@@ -20,7 +20,7 @@ public class Service {
     public Service(String service) {
         requireNonNull(service);
         checkArgument(isValidService(service), MESSAGE_CONSTRAINTS);
-        this.service = service;
+        value = service;
     }
 
     /**
@@ -30,10 +30,9 @@ public class Service {
         return test.matches(VALIDATION_REGEX);
     }
 
-
     @Override
     public String toString() {
-        return service;
+        return value;
     }
 
     @Override
@@ -48,11 +47,11 @@ public class Service {
         }
 
         Service otherService = (Service) other;
-        return service.equals(otherService.service);
+        return value.equals(otherService.value);
     }
 
     @Override
     public int hashCode() {
-        return service.hashCode();
+        return value.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/UniqueContactList.java
+++ b/src/main/java/seedu/address/model/person/UniqueContactList.java
@@ -1,0 +1,151 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.ContactNotFoundException;
+import seedu.address.model.person.exceptions.DuplicateContactException;
+
+/**
+ * A list of contacts that enforces uniqueness between its elements and does not allow nulls.
+ * A contact is considered unique by comparing using {@code Contact#isSameContact(Contact)}.
+ * As such, adding and updating of contacts uses Contact#isSameContact(Contact) for equality
+ * so as to ensure that the contact being added or updated is unique in terms of identity in
+ * the UniqueContactList. However, the removal of a contact uses Contact#equals(Object) so
+ * as to ensure that the contact with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Contact#isSameContact(Contact)
+ */
+public class UniqueContactList implements Iterable<Contact> {
+
+    private final ObservableList<Contact> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Contact> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent contact as the given argument.
+     */
+    public boolean contains(Contact toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameContact);
+    }
+
+    /**
+     * Adds a contact to the list.
+     * The contact must not already exist in the list.
+     */
+    public void add(Contact toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateContactException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the contact {@code target} in the list with {@code editedContact}.
+     * {@code target} must exist in the list.
+     * The contact identity of {@code editedContact} must not be the same as another existing contact in the list.
+     */
+    public void setContact(Contact target, Contact editedContact) {
+        requireAllNonNull(target, editedContact);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new ContactNotFoundException();
+        }
+
+        if (!target.isSameContact(editedContact) && contains(editedContact)) {
+            throw new DuplicateContactException();
+        }
+
+        internalList.set(index, editedContact);
+    }
+
+    /**
+     * Removes the equivalent contact from the list.
+     * The contact must exist in the list.
+     */
+    public void remove(Contact toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new ContactNotFoundException();
+        }
+    }
+
+    public void setContacts(UniqueContactList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code contacts}.
+     * {@code contacts} must not contain duplicate contacts.
+     */
+    public void setContacts(List<Contact> contacts) {
+        requireAllNonNull(contacts);
+        if (!contactsAreUnique(contacts)) {
+            throw new DuplicateContactException();
+        }
+
+        internalList.setAll(contacts);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Contact> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Contact> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniqueContactList)) {
+            return false;
+        }
+
+        UniqueContactList otherUniqueContactList = (UniqueContactList) other;
+        return internalList.equals(otherUniqueContactList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+
+    /**
+     * Returns true if {@code contacts} contains only unique contacts.
+     */
+    private boolean contactsAreUnique(List<Contact> contacts) {
+        for (int i = 0; i < contacts.size() - 1; i++) {
+            for (int j = i + 1; j < contacts.size(); j++) {
+                if (contacts.get(i).isSameContact(contacts.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/model/person/Vendor.java
+++ b/src/main/java/seedu/address/model/person/Vendor.java
@@ -29,6 +29,11 @@ public class Vendor extends Contact {
         requireAllNonNull(service);
         this.service = service;
     }
+
+    public Service getService() {
+        return service;
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own

--- a/src/main/java/seedu/address/model/person/exceptions/ContactNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/ContactNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified contact.
+ */
+public class ContactNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateContactException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateContactException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Contacts
+ * (Contacts are considered duplicates if they have the same identity).
+ */
+public class DuplicateContactException extends RuntimeException {
+    public DuplicateContactException() {
+        super("Operation would result in duplicate contacts");
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -7,10 +7,15 @@ import java.util.stream.Collectors;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Client;
+import seedu.address.model.person.Contact;
+import seedu.address.model.person.Date;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Service;
+import seedu.address.model.person.Vendor;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -40,10 +45,24 @@ public class SampleDataUtil {
         };
     }
 
+    public static Contact[] getSampleContacts() {
+        return new Contact[] {
+            new Client(new Name("A"), new Phone("12345678"), new Email("a@a.com"), new Address("A"),
+                new Date("01 Jan 2000"),
+                getTagSet("test")),
+            new Vendor(new Name("B"), new Phone("12345678"), new Email("b@b.com"), new Address("B"),
+                new Service("Catering"),
+                getTagSet("test")),
+        };
+    }
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
+        }
+        for (Contact sampleContact : getSampleContacts()) {
+            sampleAb.addContact(sampleContact);
         }
         return sampleAb;
     }

--- a/src/main/java/seedu/address/ui/ClientCard.java
+++ b/src/main/java/seedu/address/ui/ClientCard.java
@@ -1,0 +1,59 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Client;
+
+/**
+ * An UI component that displays information of a {@code Person}.
+ */
+public class ClientCard extends UiPart<Region> {
+
+    private static final String FXML = "ClientCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Client client;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label name;
+    @FXML
+    private Label phone;
+    @FXML
+    private Label email;
+    @FXML
+    private Label address;
+    @FXML
+    private FlowPane tags;
+
+    /**
+     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     */
+    public ClientCard(Client client, int displayedIndex) {
+        super(FXML);
+        this.client = client;
+        id.setText(displayedIndex + ". ");
+        name.setText(String.format("%s (Client)", client.getName().fullName));
+        phone.setText(client.getPhone().value);
+        email.setText(client.getEmail().value);
+        address.setText(client.getAddress().value);
+        client.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+}

--- a/src/main/java/seedu/address/ui/ContactListPanel.java
+++ b/src/main/java/seedu/address/ui/ContactListPanel.java
@@ -1,0 +1,53 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Client;
+import seedu.address.model.person.Contact;
+import seedu.address.model.person.Vendor;
+
+/**
+ * Panel containing the list of contacts.
+ */
+public class ContactListPanel extends UiPart<Region> {
+    private static final String FXML = "ContactListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ContactListPanel.class);
+
+    @FXML
+    private ListView<Contact> contactListView;
+
+    /**
+     * Creates a {@code ContactListPanel} with the given {@code ObservableList}.
+     */
+    public ContactListPanel(ObservableList<Contact> contactList) {
+        super(FXML);
+        contactListView.setItems(contactList);
+        contactListView.setCellFactory(listView -> new ContactListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Contact}
+     * using a {@code ClientCard} or a {@code VendorCard}.
+     */
+    class ContactListViewCell extends ListCell<Contact> {
+        @Override
+        protected void updateItem(Contact contact, boolean empty) {
+            super.updateItem(contact, empty);
+
+            if (empty || contact == null) {
+                setGraphic(null);
+                setText(null);
+            } else if (contact instanceof Client client) {
+                setGraphic(new ClientCard(client, getIndex() + 1).getRoot());
+            } else if (contact instanceof Vendor vendor) {
+                setGraphic(new VendorCard(vendor, getIndex() + 1).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -32,6 +32,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private ContactListPanel contactListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -43,6 +44,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private StackPane contactListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -110,8 +114,11 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        // personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        // personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+
+        contactListPanel = new ContactListPanel(logic.getFilteredContactList());
+        contactListPanelPlaceholder.getChildren().add(contactListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -165,6 +172,10 @@ public class MainWindow extends UiPart<Stage> {
 
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
+    }
+
+    public ContactListPanel getContactListPanel() {
+        return contactListPanel;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/VendorCard.java
+++ b/src/main/java/seedu/address/ui/VendorCard.java
@@ -1,0 +1,62 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.person.Vendor;
+
+/**
+ * An UI component that displays information of a {@code Person}.
+ */
+public class VendorCard extends UiPart<Region> {
+
+    private static final String FXML = "VendorCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Vendor vendor;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label id;
+    @FXML
+    private Label name;
+    @FXML
+    private Label phone;
+    @FXML
+    private Label email;
+    @FXML
+    private Label address;
+    @FXML
+    private Label service;
+    @FXML
+    private FlowPane tags;
+
+    /**
+     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     */
+    public VendorCard(Vendor vendor, int displayedIndex) {
+        super(FXML);
+        this.vendor = vendor;
+        id.setText(displayedIndex + ". ");
+        name.setText(String.format("%s (Vendor)", vendor.getName().fullName));
+        phone.setText(vendor.getPhone().value);
+        email.setText(vendor.getEmail().value);
+        address.setText(vendor.getAddress().value);
+        service.setText(vendor.getService().value);
+        vendor.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+}

--- a/src/main/resources/view/ClientCard.fxml
+++ b/src/main/resources/view/ClientCard.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15" />
+      </padding>
+      <HBox spacing="0.5" alignment="CENTER_LEFT">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+      </HBox>
+      <FlowPane fx:id="tags" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+    </VBox>
+  </GridPane>
+</HBox>

--- a/src/main/resources/view/ContactListPanel.fxml
+++ b/src/main/resources/view/ContactListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="contactListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -328,7 +328,7 @@
     -fx-text-fill: white;
 }
 
-#filterField, #personListPanel, #personWebpage {
+#filterField, #personListPanel, #personWebpage, #contactListPanel {
     -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
 }
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,11 +46,18 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <!-- <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
           <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox> -->
+
+        <VBox fx:id="contactList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="contactListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/VendorCard.fxml
+++ b/src/main/resources/view/VendorCard.fxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets top="5" right="5" bottom="5" left="15" />
+      </padding>
+      <HBox spacing="0.5" alignment="CENTER_LEFT">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+      </HBox>
+      <FlowPane fx:id="tags" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+      <Label fx:id="service" styleClass="cell_small_label" text="\$service" />
+    </VBox>
+  </GridPane>
+</HBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -150,6 +151,11 @@ public class AddCommandTest {
 
         @Override
         public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Contact> getFilteredContactList() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Contact;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -85,7 +86,9 @@ public class AddressBookTest {
 
     @Test
     public void toStringMethod() {
-        String expected = AddressBook.class.getCanonicalName() + "{persons=" + addressBook.getPersonList() + "}";
+        String expected = AddressBook.class.getCanonicalName()
+                + "{persons=" + addressBook.getPersonList()
+                + ", contacts=" + addressBook.getContactList() + "}";
         assertEquals(expected, addressBook.toString());
     }
 
@@ -94,6 +97,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Contact> contacts = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -102,6 +106,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Contact> getContactList() {
+            return contacts;
         }
     }
 


### PR DESCRIPTION
## Description

Closes #64. Requires #65 to be merged first. I was originally intending to just implement the `ClientCard`, `VendorCard` and `ContactListPanel` classes by adpating `PersonCard` and `PersonListPanel`. However, after doing so, I realised that there was no way to test if the implementations were correct without rendering the cards. Instead, I have adapted some of the logic required to render `Contact` cards.

## Changes

- [x] Add `ClientCard`, `VendorCard` and `ContactListPanel` classes and `.fxml` files
- [x] Modify `MainWindow` to display `ContactListPanel`
- [x] Add logic to render `Contact` instead of `Person`
- [x] Add sample `Contact` data

## Preview

![Screenshot 2024-10-07 025607](https://github.com/user-attachments/assets/2e8490a4-583c-4dd1-b530-113c808b48d0)
