### PR TITLE
Fix test fails

### DIFF
--- a/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalAddressBook.json
@@ -7,7 +7,7 @@
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "tags" : [ "friends" ],
-    "id" : 1,
+    "id" : 11,
     "eventIds": [0]
   }, {
     "type" : "vendor",
@@ -17,7 +17,7 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "service" : "flower provider",
     "tags" : [ "owesMoney", "friends" ],
-    "id" : 2,
+    "id" : 12,
     "eventIds": [0, 1]
   }, {
     "type" : "client",
@@ -26,7 +26,7 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "tags" : [ ],
-    "id" : 3,
+    "id" : 13,
     "eventIds": [0]
   }, {
     "type" : "vendor",
@@ -36,7 +36,7 @@
     "address" : "10th street",
     "service" : "Photography",
     "tags" : [ "friends" ],
-    "id": 4,
+    "id": 14,
     "eventIds": [0, 1]
   }, {
     "type" : "client",
@@ -45,7 +45,7 @@
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "tags" : [ ],
-    "id" : 5,
+    "id" : 15,
     "eventIds": [1]
   }, {
     "type" : "client",
@@ -54,7 +54,7 @@
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "tags" : [ ],
-    "id" : 6,
+    "id" : 16,
     "eventIds": [1]
   }, {
     "type" : "vendor",
@@ -64,7 +64,7 @@
     "address" : "4th street",
     "service" : "catering",
     "tags" : [ ],
-    "id" : 7,
+    "id" : 17,
     "eventIds": [1]
   } ],
   "events" : [ {
@@ -72,16 +72,16 @@
     "description": "This is wedding A",
     "date" : "2000-01-01",
     "eventId": 0,
-    "clientIds": [1, 3],
-    "vendorIds": [2, 4]
+    "clientIds": [11, 13],
+    "vendorIds": [12, 14]
   }, {
     "name" : "Sample Wedding",
     "description": "This is wedding B",
     "date" : "2000-01-01",
     "eventId": 1,
-    "clientIds": [5, 6],
-    "vendorIds": [2, 4, 7]
+    "clientIds": [15, 16],
+    "vendorIds": [12, 14, 17]
   }],
-  "nextContactId": 8,
+  "nextContactId": 18,
   "nextEventId": 2
 }

--- a/src/test/java/seedu/ddd/model/ModelManagerTest.java
+++ b/src/test/java/seedu/ddd/model/ModelManagerTest.java
@@ -9,6 +9,7 @@ import static seedu.ddd.testutil.contact.TypicalContacts.ALICE;
 import static seedu.ddd.testutil.contact.TypicalContacts.BENSON;
 import static seedu.ddd.testutil.contact.TypicalContacts.CARL;
 import static seedu.ddd.testutil.contact.TypicalContacts.DANIEL;
+import static seedu.ddd.testutil.contact.TypicalContacts.ELLE;
 import static seedu.ddd.testutil.contact.TypicalContacts.VALID_CLIENT;
 import static seedu.ddd.testutil.contact.TypicalContacts.VALID_VENDOR;
 import static seedu.ddd.testutil.event.TypicalEvents.VALID_EVENT;
@@ -172,7 +173,7 @@ public class ModelManagerTest {
         testModelManager.addEvent(WEDDING_A);
         assertTrue(testModelManager.getDisplayedList().contains(WEDDING_A));
 
-        testModelManager.deleteContact(VALID_CLIENT); // when a contact is added, displayedList should display contacts
+        testModelManager.addContact(ELLE); // when a contact is added, displayedList should display contacts
         testModelManager.deleteEvent(VALID_EVENT);
         assertTrue(testModelManager.getDisplayedList().contains(WEDDING_A));
     }

--- a/src/test/java/seedu/ddd/testutil/contact/TypicalContacts.java
+++ b/src/test/java/seedu/ddd/testutil/contact/TypicalContacts.java
@@ -32,7 +32,7 @@ public class TypicalContacts {
             .withEmail("alice@example.com")
             .withPhone("94351253")
             .withTags("friends")
-            .withId(1)
+            .withId(11)
             .build();
     public static final Vendor BENSON = new VendorBuilder()
             .withName("Benson Meier")
@@ -41,7 +41,7 @@ public class TypicalContacts {
             .withPhone("98765432")
             .withService("flower provider")
             .withTags("owesMoney", "friends")
-            .withId(2)
+            .withId(12)
             .build();
     public static final Client CARL = new ClientBuilder()
             .withName("Carl Kurz")
@@ -49,7 +49,7 @@ public class TypicalContacts {
             .withEmail("heinz@example.com")
             .withAddress("wall street")
             .withTags()
-            .withId(3)
+            .withId(13)
             .build();
     public static final Vendor DANIEL = new VendorBuilder()
             .withName("Daniel Meier")
@@ -58,7 +58,7 @@ public class TypicalContacts {
             .withAddress("10th street")
             .withService("Photography")
             .withTags("friends")
-            .withId(4)
+            .withId(14)
             .build();
     public static final Client ELLE = new ClientBuilder()
             .withName("Elle Meyer")
@@ -66,7 +66,7 @@ public class TypicalContacts {
             .withEmail("werner@example.com")
             .withAddress("michegan ave")
             .withTags()
-            .withId(5)
+            .withId(15)
             .build();
     public static final Client FIONA = new ClientBuilder()
             .withName("Fiona Kunz")
@@ -74,7 +74,7 @@ public class TypicalContacts {
             .withEmail("lydia@example.com")
             .withAddress("little tokyo")
             .withTags()
-            .withId(6)
+            .withId(16)
             .build();
     public static final Vendor GEORGE = new VendorBuilder()
             .withName("George Best")
@@ -83,7 +83,7 @@ public class TypicalContacts {
             .withAddress("4th street")
             .withService("catering")
             .withTags()
-            .withId(7)
+            .withId(17)
             .build();
 
     // Manually added
@@ -93,14 +93,14 @@ public class TypicalContacts {
             .withEmail("stefan@example.com")
             .withAddress("little india")
             .withTags()
-            .withId(8)
+            .withId(18)
             .build();
     public static final Client IDA = new ClientBuilder()
             .withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com")
             .withAddress("chicago ave")
             .withTags()
-            .withId(9)
+            .withId(19)
             .build();
 
     // Manually added - Contacts' details found in {@code CommandTestUtil}


### PR DESCRIPTION
## Description

Fixes #172.

In `src/test/java/seedu/ddd/model/ModelManagerTest.java`, deleting `VALID_CONTACT` caused `VALID_EVENT` to be deleted as well, so `VALID_EVENT` cannot be deleted again.

The other test fails were caused because both `VALID_VENDOR` and `BENSON` had an ID of 1. I've modified the IDs for all of the `ALICE`, `BENSON` etc because the `VALID_VENDOR` ID comes from `sampleDataUtil`.