### PR TITLE
Increase ResultDisplay size

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,11 +46,11 @@
 
           <VBox styleClass="padding-8" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
             <StackPane fx:id="contactListPanelPlaceholder"
-                       VBox.vgrow="ALWAYS" maxHeight="Infinity" minHeight="200" />
-            <StackPane styleClass="padding-8" maxHeight="160" minHeight="120" prefHeight="160">
+                       VBox.vgrow="ALWAYS" maxHeight="Infinity" minHeight="180" />
+            <StackPane styleClass="padding-8" maxHeight="220" minHeight="140" prefHeight="220">
               <VBox>
                 <StackPane fx:id="resultDisplayPlaceholder" styleClass=""
-                           maxHeight="100" minHeight="60" prefHeight="100"/>
+                           maxHeight="160" minHeight="80" prefHeight="160"/>
                 <StackPane fx:id="commandBoxPlaceholder" styleClass=""
                            maxHeight="60" minHeight="60" prefHeight="60" />
               </VBox>


### PR DESCRIPTION
## Description

Increases size of `ResultDisplay` as requested by @yizhong187. The text box will minimally be able to contain 2 lines of text.

### Minimum size

![Screenshot 2024-11-02 014241](https://github.com/user-attachments/assets/e9ded6cd-8902-403f-8bc0-5f1c7a349292)

### Maximum size

![Screenshot 2024-11-02 014251](https://github.com/user-attachments/assets/2b4286d9-12d8-4a2f-825c-e27bdac03432)
