### PR TITLE
Id not found should throw exception

### DIFF
--- a/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
@@ -76,8 +76,7 @@ public class EditContactCommand extends EditCommand {
                 }
             }
             if (contactToEdit == null) {
-                throw new CommandException(String.format(
-                    Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX, targetContactId));
+                throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
 
             }
         }

--- a/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
@@ -75,6 +75,11 @@ public class EditContactCommand extends EditCommand {
                     break;
                 }
             }
+            if (contactToEdit == null) {
+                throw new CommandException(String.format(
+                    Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX, targetContactId));
+
+            }
         }
         assert contactToEdit != null;
 

--- a/src/main/java/seedu/ddd/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/ddd/logic/parser/EditCommandParser.java
@@ -40,15 +40,14 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_ADDRESS, PREFIX_SERVICE, PREFIX_TAG, PREFIX_ID);
 
         Index index = null;
-        // Either index or id/ parameter must be specified
-        try {
+        if (!argMultimap.getPreamble().isEmpty()) {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            if (argMultimap.getValue(PREFIX_ID).isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
-            }
         }
-        // Cannot specify both index and id/
+        // either index or id/ parameter must be specified
+        if (index == null && argMultimap.getValue(PREFIX_ID).isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
+        // cannot specify both index and id/
         if (index != null && !argMultimap.getValue(PREFIX_ID).isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }

--- a/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
@@ -287,8 +287,7 @@ public class EditContactCommandTest {
                 .withId(invalidIdString)
                 .build();
         EditCommand editCommand = new EditContactCommand(null, descriptor);
-        String expectedMessage = String.format(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX, invalidIdString);
-        assertCommandFailure(editCommand, model, expectedMessage);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
@@ -281,6 +281,17 @@ public class EditContactCommandTest {
     }
 
     @Test
+    public void execute_invalidContactId_failure() {
+        String invalidIdString = "10000";
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
+                .withId(invalidIdString)
+                .build();
+        EditCommand editCommand = new EditContactCommand(null, descriptor);
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX, invalidIdString);
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
     public void execute_validClient_shouldUpdateEvents() {
         // first contact should be ALICE
         Index targetIndex = INDEX_FIRST_CONTACT;

--- a/src/test/java/seedu/ddd/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/ddd/logic/parser/EditCommandParserTest.java
@@ -25,6 +25,7 @@ import static seedu.ddd.logic.parser.CommandParserTestUtil.VALID_VENDOR_PHONE_AR
 import static seedu.ddd.logic.parser.CommandParserTestUtil.VALID_VENDOR_SERVICE_ARGUMENT;
 import static seedu.ddd.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.ddd.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.ddd.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.ddd.testutil.TypicalIndexes.INDEX_FIRST_CONTACT;
 import static seedu.ddd.testutil.TypicalIndexes.INDEX_SECOND_CONTACT;
 import static seedu.ddd.testutil.TypicalIndexes.INDEX_THIRD_CONTACT;
@@ -67,7 +68,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_CLIENT_NAME, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_CLIENT_NAME, MESSAGE_INVALID_INDEX);
 
         // no field specified
         assertParseFailure(parser, "1", EditContactCommand.MESSAGE_NOT_EDITED);
@@ -79,16 +80,32 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_INDEX);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_invalidId_failure() {
+        // negative ID
+        assertParseFailure(parser, "id/-1" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_INDEX);
+
+        // zero ID
+        assertParseFailure(parser, "id/0" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_INDEX);
+    }
+
+    @Test
+    public void parse_invalidIdOrIndex_failure() {
+        // either index or id/ parameter must be specified
+        assertParseFailure(parser, " " + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 id/1" + VALID_CLIENT_NAME_ARGUMENT, MESSAGE_INVALID_FORMAT);
     }
 
     @Test


### PR DESCRIPTION
## Description

Closes #206.

- `EditCommand` should throw a `CommandException` if the provided ID is not valid
- Standardize invalid index messages