### PR TITLE
Fix unable to add duplicate desc event

### DIFF
--- a/src/main/java/seedu/ddd/logic/commands/add/AddEventCommand.java
+++ b/src/main/java/seedu/ddd/logic/commands/add/AddEventCommand.java
@@ -110,7 +110,7 @@ public class AddEventCommand extends AddCommand {
         assert !clientsToAdd.isEmpty();
 
         Event eventToAdd = new Event(name, description, date, clientsToAdd, vendorsToAdd, eventId);
-        if (model.hasEventName(eventToAdd.getName())) {
+        if (model.hasEvent(eventToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_EVENT);
         }
         model.addEvent(eventToAdd);

--- a/src/main/java/seedu/ddd/model/AddressBook.java
+++ b/src/main/java/seedu/ddd/model/AddressBook.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 import javafx.collections.ObservableList;
 import seedu.ddd.commons.util.ToStringBuilder;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.contact.client.Client;
 import seedu.ddd.model.contact.common.Contact;
 import seedu.ddd.model.contact.common.UniqueContactList;
@@ -110,14 +109,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasEvent(Event event) {
         requireNonNull(event);
         return events.contains(event);
-    }
-
-    /**
-     * Returns true if an event with the same name as {@code event} exists in the address book.
-     */
-    public boolean hasEventName(Name eventName) {
-        requireNonNull(eventName);
-        return events.containsName(eventName);
     }
 
     /**

--- a/src/main/java/seedu/ddd/model/Model.java
+++ b/src/main/java/seedu/ddd/model/Model.java
@@ -6,7 +6,6 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.ddd.commons.core.GuiSettings;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.contact.common.Contact;
 import seedu.ddd.model.event.common.Event;
 
@@ -75,11 +74,6 @@ public interface Model {
      * Returns true if an event with the same identity as {@code event} exists in the address book.
      */
     boolean hasEvent(Event event);
-
-    /**
-     * Returns true if an event with the same name as {@code event} exists in the address book.
-     */
-    boolean hasEventName(Name eventName);
 
     /**
      * Deletes the given person.

--- a/src/main/java/seedu/ddd/model/ModelManager.java
+++ b/src/main/java/seedu/ddd/model/ModelManager.java
@@ -14,7 +14,6 @@ import seedu.ddd.commons.core.GuiSettings;
 import seedu.ddd.commons.core.LogsCenter;
 import seedu.ddd.commons.util.CollectionUtil;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.contact.common.Contact;
 import seedu.ddd.model.event.common.Event;
 
@@ -139,12 +138,6 @@ public class ModelManager implements Model {
     public void deleteContact(Contact target) {
         addressBook.deleteContact(target);
         displayContacts();
-    }
-
-    @Override
-    public boolean hasEventName(Name eventName) {
-        requireNonNull(eventName);
-        return addressBook.hasEventName(eventName);
     }
 
     @Override

--- a/src/main/java/seedu/ddd/model/event/common/Event.java
+++ b/src/main/java/seedu/ddd/model/event/common/Event.java
@@ -4,10 +4,8 @@ import static seedu.ddd.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import seedu.ddd.commons.util.ToStringBuilder;
 import seedu.ddd.model.Displayable;
@@ -200,12 +198,7 @@ public class Event implements Displayable {
      * @return A boolean value which represents the result.
      */
     public boolean isSameEvent(Event otherEvent) {
-        Set<Client> thisClients = new HashSet<>(this.getClients());
-        Set<Client> otherClients = new HashSet<>(otherEvent.getClients());
-        Description thisDescription = this.getDescription();
-        Description otherDescription = otherEvent.getDescription();
-        return thisClients.equals(otherClients)
-                && thisDescription.equals(otherDescription);
+        return this.getName().equals(otherEvent.getName());
     }
 
     @Override
@@ -220,17 +213,7 @@ public class Event implements Displayable {
         }
 
         Event otherEvent = (Event) other;
-
-        Set<Client> thisClients = new HashSet<>(this.getClients());
-        Set<Vendor> thisVendors = new HashSet<>(this.getVendors());
-        Set<Client> otherClients = new HashSet<>(otherEvent.getClients());
-        Set<Vendor> otherVendors = new HashSet<>(otherEvent.getVendors());
-
-        return thisClients.equals(otherClients)
-                && thisVendors.equals(otherVendors)
-                && this.description.equals(otherEvent.description)
-                && this.name.equals(otherEvent.name)
-                && this.date.equals(otherEvent.date);
+        return this.getName().equals(otherEvent.getName());
     }
 
     @Override

--- a/src/main/java/seedu/ddd/model/event/common/UniqueEventList.java
+++ b/src/main/java/seedu/ddd/model/event/common/UniqueEventList.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.ddd.commons.util.CollectionUtil;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.event.exceptions.DuplicateEventException;
 import seedu.ddd.model.event.exceptions.EventNotFoundException;
 
@@ -40,14 +39,6 @@ public class UniqueEventList implements Iterable<Event> {
     public boolean contains(Event toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameEvent);
-    }
-
-    /**
-     * Returns true if the list contains an event with the equivalent name as the given argument.
-     */
-    public boolean containsName(Name toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(event -> event.getName().equals(toCheck));
     }
 
     /**

--- a/src/test/java/seedu/ddd/logic/commands/add/AddContactCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/add/AddContactCommandTest.java
@@ -25,7 +25,6 @@ import seedu.ddd.model.Model;
 import seedu.ddd.model.ReadOnlyAddressBook;
 import seedu.ddd.model.ReadOnlyUserPrefs;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.contact.common.Contact;
 import seedu.ddd.model.event.common.Event;
 import seedu.ddd.testutil.contact.ClientBuilder;

--- a/src/test/java/seedu/ddd/logic/commands/add/AddContactCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/add/AddContactCommandTest.java
@@ -188,11 +188,6 @@ public class AddContactCommandTest {
         }
 
         @Override
-        public boolean hasEventName(Name eventName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void deleteContact(Contact target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/ddd/logic/commands/add/AddEventCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/add/AddEventCommandTest.java
@@ -36,7 +36,6 @@ import seedu.ddd.model.Model;
 import seedu.ddd.model.ReadOnlyAddressBook;
 import seedu.ddd.model.ReadOnlyUserPrefs;
 import seedu.ddd.model.common.Id;
-import seedu.ddd.model.common.Name;
 import seedu.ddd.model.contact.common.Contact;
 import seedu.ddd.model.event.common.Description;
 import seedu.ddd.model.event.common.Event;

--- a/src/test/java/seedu/ddd/logic/commands/add/AddEventCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/add/AddEventCommandTest.java
@@ -274,11 +274,6 @@ public class AddEventCommandTest {
         }
 
         @Override
-        public boolean hasEventName(Name eventName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void deleteContact(Contact target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -347,12 +342,6 @@ public class AddEventCommandTest {
         }
 
         @Override
-        public boolean hasEventName(Name eventName) {
-            requireNonNull(eventName);
-            return eventsAdded.stream().anyMatch(event -> event.getName().equals(eventName));
-        }
-
-        @Override
         public void addEvent(Event event) {
             requireNonNull(event);
             eventsAdded.add(event);
@@ -395,12 +384,6 @@ public class AddEventCommandTest {
         public boolean hasEvent(Event event) {
             requireNonNull(event);
             return eventsAdded.stream().anyMatch(event::isSameEvent);
-        }
-
-        @Override
-        public boolean hasEventName(Name eventName) {
-            requireNonNull(eventName);
-            return eventsAdded.stream().anyMatch(event -> event.getName().equals(eventName));
         }
 
         @Override

--- a/src/test/java/seedu/ddd/model/AddressBookTest.java
+++ b/src/test/java/seedu/ddd/model/AddressBookTest.java
@@ -155,22 +155,6 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasEventName_validEvent_returnsTrue() {
-        addressBook = getTypicalAddressBook();
-        assertTrue(addressBook.hasEventName(WEDDING_A.getName()));
-    }
-
-    @Test
-    public void hasEventName_invalidEvent_returnsFalse() {
-        // empty addressbook
-        assertFalse(addressBook.hasEventName(WEDDING_A.getName()));
-
-        addressBook = getTypicalAddressBook();
-        assertTrue(addressBook.hasEventName(WEDDING_A.getName()));
-        assertFalse(addressBook.hasEventName(VALID_EVENT.getName()));
-    }
-
-    @Test
     public void toStringMethod() {
         String expected = AddressBook.class.getCanonicalName()
                 + "{contacts=" + addressBook.getContactList() + ","

--- a/src/test/java/seedu/ddd/model/ModelManagerTest.java
+++ b/src/test/java/seedu/ddd/model/ModelManagerTest.java
@@ -162,22 +162,6 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void hasEventName_validEvent_returnsTrue() {
-        modelManager = new ModelManager(getTypicalAddressBook(), modelManager.getUserPrefs());
-        assertTrue(modelManager.hasEventName(WEDDING_A.getName()));
-    }
-
-    @Test
-    public void hasEventName_invalidEvent_returnsFalse() {
-        // empty addressbook
-        assertFalse(modelManager.hasEventName(WEDDING_A.getName()));
-
-        modelManager = new ModelManager(getTypicalAddressBook(), modelManager.getUserPrefs());
-        assertTrue(modelManager.hasEventName(WEDDING_A.getName()));
-        assertFalse(modelManager.hasEventName(VALID_EVENT.getName()));
-    }
-
-    @Test
     public void getFilteredContactList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredContactList().remove(0));
     }

--- a/src/test/java/seedu/ddd/model/event/common/EventTest.java
+++ b/src/test/java/seedu/ddd/model/event/common/EventTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.ddd.testutil.Assert.assertThrows;
+import static seedu.ddd.testutil.contact.TypicalContactFields.VALID_CLIENT_NAME;
 import static seedu.ddd.testutil.contact.TypicalContacts.ALICE;
 import static seedu.ddd.testutil.contact.TypicalContacts.BENSON;
 import static seedu.ddd.testutil.contact.TypicalContacts.VALID_CLIENT;
@@ -15,6 +16,7 @@ import static seedu.ddd.testutil.event.TypicalEventFields.DEFAULT_EVENT_ID;
 import static seedu.ddd.testutil.event.TypicalEventFields.DEFAULT_EVENT_NAME;
 import static seedu.ddd.testutil.event.TypicalEventFields.DEFAULT_EVENT_VENDOR_LIST;
 import static seedu.ddd.testutil.event.TypicalEventFields.VALID_EVENT_DESCRIPTION_2;
+import static seedu.ddd.testutil.event.TypicalEventFields.VALID_EVENT_NAME_1;
 import static seedu.ddd.testutil.event.TypicalEvents.VALID_EVENT;
 import static seedu.ddd.testutil.event.TypicalEvents.WEDDING_A;
 import static seedu.ddd.testutil.event.TypicalEvents.WEDDING_B;
@@ -63,22 +65,27 @@ public class EventTest {
     public void isSameEvent() {
         assertTrue(WEDDING_A.isSameEvent(WEDDING_A));
 
-        // different description
+        // different name
         Event copied = new EventBuilder(WEDDING_A)
+                .withName(VALID_EVENT_NAME_1)
+                .build();
+        assertFalse(WEDDING_A.isSameEvent(copied));
+
+        // different description
+        copied = new EventBuilder(WEDDING_A)
             .withDescription(VALID_EVENT_DESCRIPTION_2)
             .build();
-        assertFalse(WEDDING_A.isSameEvent(copied));
+        assertTrue(WEDDING_A.isSameEvent(copied));
 
         // different clients
         copied = new EventBuilder(WEDDING_A)
             .withClients(ALICE)
             .build();
-        assertFalse(WEDDING_A.isSameEvent(copied));
+        assertTrue(WEDDING_A.isSameEvent(copied));
 
-        // same description and clients
+        // same name
         copied = new EventBuilder(WEDDING_B)
-            .withClients(WEDDING_A.getClients())
-            .withDescription(WEDDING_A.getDescription().description)
+            .withName(WEDDING_A.getName().fullName)
             .build();
         assertTrue(WEDDING_A.isSameEvent(copied));
 
@@ -101,23 +108,29 @@ public class EventTest {
         Event copied = new EventBuilder(WEDDING_A).build();
         assertEquals(WEDDING_A, copied);
 
+        // different name
+        copied = new EventBuilder(WEDDING_A)
+                .withName(VALID_CLIENT_NAME)
+                .build();
+        assertNotEquals(WEDDING_A, copied);
+
         // different clients
         copied = new EventBuilder(WEDDING_A)
-            .withClients(ALICE)
-            .build();
-        assertNotEquals(WEDDING_A, copied);
+                .withClients(ALICE)
+                .build();
+        assertEquals(WEDDING_A, copied);
 
         // different vendors
         copied = new EventBuilder(WEDDING_A)
-            .withVendors(BENSON)
-            .build();
-        assertNotEquals(WEDDING_A, copied);
+                .withVendors(BENSON)
+                .build();
+        assertEquals(WEDDING_A, copied);
 
         // different description
         copied = new EventBuilder(WEDDING_A)
-            .withDescription(WEDDING_B.getDescription().description)
-            .build();
-        assertNotEquals(WEDDING_A, copied);
+                .withDescription(WEDDING_B.getDescription().description)
+                .build();
+        assertEquals(WEDDING_A, copied);
     }
 
 

--- a/src/test/java/seedu/ddd/model/event/common/UniqueEventListTest.java
+++ b/src/test/java/seedu/ddd/model/event/common/UniqueEventListTest.java
@@ -50,21 +50,9 @@ public class UniqueEventListTest {
     public void contains_contactWithSameIdentityFieldsInList_returnsTrue() {
         uniqueEventList.add(WEDDING_A);
         Event editedWeddingA = new EventBuilder(WEDDING_B)
-            .withDescription(WEDDING_A.getDescription().description)
-            .withClients(WEDDING_A.getClients())
+            .withName(WEDDING_A.getName().fullName)
             .build();
         assertTrue(uniqueEventList.contains(editedWeddingA));
-    }
-
-    @Test
-    public void containsName_eventNotInList_returnFalse() {
-        assertFalse(uniqueEventList.containsName(WEDDING_A.getName()));
-    }
-
-    @Test
-    public void containsName_eventInList_returnTrue() {
-        uniqueEventList.add(WEDDING_A);
-        assertTrue(uniqueEventList.containsName(WEDDING_A.getName()));
     }
 
     @Test


### PR DESCRIPTION
Event's equals method was comparing the client list and description, rather than the name. Fix event's equals method, and removed all methods used to check for name equality.

Fix all test cases associated as well.