### PR TITLE
Alpha-bug fixes

### DIFF
--- a/src/main/java/seedu/ddd/MainApp.java
+++ b/src/main/java/seedu/ddd/MainApp.java
@@ -49,7 +49,7 @@ public class MainApp extends Application {
 
     @Override
     public void init() throws Exception {
-        logger.info("=============================[ Initializing AddressBook ]===========================");
+        logger.info("=============================[ Initializing Dream Day Designer ]===========================");
         super.init();
 
         AppParameters appParameters = AppParameters.parse(getParameters());

--- a/src/main/java/seedu/ddd/MainApp.java
+++ b/src/main/java/seedu/ddd/MainApp.java
@@ -170,13 +170,13 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        logger.info("Starting AddressBook " + MainApp.VERSION);
+        logger.info("Starting DDD " + MainApp.VERSION);
         ui.start(primaryStage);
     }
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping AddressBook ] =============================");
+        logger.info("============================ [ Stopping Dream Day Designer ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/ddd/logic/Messages.java
+++ b/src/main/java/seedu/ddd/logic/Messages.java
@@ -36,6 +36,7 @@ public class Messages {
     public static final String MESSAGE_DEPENDENT_EVENT =
             "Unable to delete client!\n Event(s) %1$s depend on the client you are trying to delete.";
     public static final String MESSAGE_EXCLUSIVE_FLAGS = "Only 1 of the following flags can be specified: ";
+    public static final String MESSAGE_NOT_DISPLAYING_CONTACTS = "The displayed list does not contain contacts.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/ddd/logic/commands/EditContactCommand.java
@@ -5,16 +5,17 @@ import static seedu.ddd.logic.parser.CliSyntax.PREFIX_SERVICE;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import javafx.collections.ObservableList;
 import seedu.ddd.commons.core.index.Index;
 import seedu.ddd.commons.util.CollectionUtil;
 import seedu.ddd.commons.util.ToStringBuilder;
 import seedu.ddd.logic.Messages;
 import seedu.ddd.logic.commands.exceptions.CommandException;
+import seedu.ddd.model.Displayable;
 import seedu.ddd.model.Model;
 import seedu.ddd.model.common.Id;
 import seedu.ddd.model.common.Name;
@@ -59,12 +60,16 @@ public class EditContactCommand extends EditCommand {
 
         Contact contactToEdit = null;
         if (index != null) {
-            List<Contact> lastShownList = model.getFilteredContactList();
+            ObservableList<Displayable> lastShownList = model.getDisplayedList();
             if (index.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
             }
-
-            contactToEdit = lastShownList.get(index.getZeroBased());
+            Displayable firstItem = lastShownList.get(index.getZeroBased());
+            if (!(firstItem instanceof Contact)) {
+                throw new CommandException(Messages.MESSAGE_NOT_DISPLAYING_CONTACTS);
+            }
+            assert firstItem instanceof Contact;
+            contactToEdit = (Contact) firstItem;
         } else {
             Id targetContactId = editContactDescriptor.getId().get();
             assert targetContactId != null;

--- a/src/main/java/seedu/ddd/model/UserPrefs.java
+++ b/src/main/java/seedu/ddd/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.ddd.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private Path addressBookFilePath = Paths.get("data" , "ddd.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.

--- a/src/main/java/seedu/ddd/model/common/Name.java
+++ b/src/main/java/seedu/ddd/model/common/Name.java
@@ -29,7 +29,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         AppUtil.checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        fullName = capitalizeName(name);
     }
 
     /**
@@ -65,4 +65,18 @@ public class Name {
         return fullName.hashCode();
     }
 
+    private String capitalizeName(String name) {
+        String[] words = name.toLowerCase().split("\\s+");
+        StringBuilder capitalized = new StringBuilder();
+
+        for (String word : words) {
+            if (!word.isEmpty()) {
+                capitalized.append(Character.toUpperCase(word.charAt(0)))
+                        .append(word.substring(1))
+                        .append(" ");
+            }
+        }
+
+        return capitalized.toString().trim();
+    }
 }

--- a/src/main/java/seedu/ddd/model/common/Name.java
+++ b/src/main/java/seedu/ddd/model/common/Name.java
@@ -29,7 +29,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         AppUtil.checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = capitalizeName(name);
+        fullName = name.trim();
     }
 
     /**
@@ -39,7 +39,12 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
-
+    /**
+     * Returns true if a given {@code Name} is the same as the current Name object.
+     */
+    public boolean isSameName(Name name) {
+        return fullName.equalsIgnoreCase(name.fullName);
+    }
     @Override
     public String toString() {
         return fullName;
@@ -63,20 +68,5 @@ public class Name {
     @Override
     public int hashCode() {
         return fullName.hashCode();
-    }
-
-    private String capitalizeName(String name) {
-        String[] words = name.toLowerCase().split("\\s+");
-        StringBuilder capitalized = new StringBuilder();
-
-        for (String word : words) {
-            if (!word.isEmpty()) {
-                capitalized.append(Character.toUpperCase(word.charAt(0)))
-                        .append(word.substring(1))
-                        .append(" ");
-            }
-        }
-
-        return capitalized.toString().trim();
     }
 }

--- a/src/main/java/seedu/ddd/model/contact/common/Address.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Address.java
@@ -32,12 +32,11 @@ public class Address {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid address.
      */
     public static boolean isValidAddress(String test) {
         return test.matches(VALIDATION_REGEX);
     }
-
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/ddd/model/contact/common/Contact.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Contact.java
@@ -111,7 +111,7 @@ public abstract class Contact implements Displayable {
     }
 
     /**
-     * Returns true if both persons have the same name and phone number.
+     * Returns true if both persons have the same name or phone number.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSameContact(Contact otherContact) {

--- a/src/main/java/seedu/ddd/model/contact/common/Contact.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Contact.java
@@ -120,7 +120,7 @@ public abstract class Contact implements Displayable {
         }
 
         return otherContact != null
-                && (otherContact.getName().equals(name)
+                && (otherContact.getName().isSameName(name)
                 || otherContact.getPhone().equals(phone));
     }
 

--- a/src/main/java/seedu/ddd/model/contact/common/Contact.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Contact.java
@@ -111,7 +111,7 @@ public abstract class Contact implements Displayable {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same name and phone number.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSameContact(Contact otherContact) {
@@ -120,7 +120,8 @@ public abstract class Contact implements Displayable {
         }
 
         return otherContact != null
-                && otherContact.getName().equals(getName());
+                && (otherContact.getName().equals(name)
+                || otherContact.getPhone().equals(phone));
     }
 
     /**

--- a/src/main/java/seedu/ddd/model/event/common/Event.java
+++ b/src/main/java/seedu/ddd/model/event/common/Event.java
@@ -193,12 +193,12 @@ public class Event implements Displayable {
     /**
      * Return if the two events are the same.
      *
-     * Two events are considered the same if they have the same client and date.
+     * Two events are considered the same if they have the same name.
      * @param otherEvent Another event.
      * @return A boolean value which represents the result.
      */
     public boolean isSameEvent(Event otherEvent) {
-        return this.getName().equals(otherEvent.getName());
+        return this.getName().isSameName(otherEvent.getName());
     }
 
     @Override

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "ddd.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "ddd.json"
 }

--- a/src/test/java/seedu/ddd/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/ddd/logic/LogicManagerTest.java
@@ -36,7 +36,7 @@ public class LogicManagerTest {
     @BeforeEach
     public void setUp() {
         JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+                new JsonAddressBookStorage(temporaryFolder.resolve("ddd.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);

--- a/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/ddd/logic/commands/EditContactCommandTest.java
@@ -291,6 +291,15 @@ public class EditContactCommandTest {
     }
 
     @Test
+    public void execute_invalidDisplay_failure() {
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().build();
+        model.updateFilteredEventList(Model.PREDICATE_SHOW_ALL_EVENTS);
+        EditCommand editCommand = new EditContactCommand(INDEX_FIRST_EVENT, descriptor);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_NOT_DISPLAYING_CONTACTS);
+    }
+
+
+    @Test
     public void execute_validClient_shouldUpdateEvents() {
         // first contact should be ALICE
         Index targetIndex = INDEX_FIRST_CONTACT;

--- a/src/test/java/seedu/ddd/model/contact/common/ContactTest.java
+++ b/src/test/java/seedu/ddd/model/contact/common/ContactTest.java
@@ -3,6 +3,7 @@ package seedu.ddd.model.contact.common;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.ddd.testutil.Assert.assertThrows;
+import static seedu.ddd.testutil.contact.TypicalContactFields.VALID_CLIENT_PHONE;
 import static seedu.ddd.testutil.contact.TypicalContactFields.VALID_TAG_1;
 import static seedu.ddd.testutil.contact.TypicalContactFields.VALID_TAG_2;
 import static seedu.ddd.testutil.contact.TypicalContactFields.VALID_VENDOR_ADDRESS;
@@ -53,19 +54,35 @@ public class ContactTest {
                 .build();
         assertTrue(VALID_CLIENT.isSameContact(otherClient));
 
-        // different name, all other attributes same -> returns false
-        otherClient = new ClientBuilder(VALID_CLIENT).withName(VALID_VENDOR_NAME).build();
+        // same phone, all other attributes different -> returns true
+        otherClient = new ClientBuilder(VALID_CLIENT)
+                .withName(VALID_VENDOR_NAME)
+                .withEmail(VALID_VENDOR_EMAIL)
+                .withAddress(VALID_VENDOR_ADDRESS)
+                .withTags(VALID_TAG_1)
+                .build();
+        assertTrue(VALID_CLIENT.isSameContact(otherClient));
+
+        // different name and phone, all other attributes same -> returns false
+        otherClient = new ClientBuilder(VALID_CLIENT)
+                .withName(VALID_VENDOR_NAME)
+                .withPhone(VALID_VENDOR_PHONE)
+                .build();
         assertFalse(VALID_CLIENT.isSameContact(otherClient));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case and different phone, all other attributes same -> returns false
         Contact otherVendor = new VendorBuilder(VALID_VENDOR)
                 .withName(VALID_VENDOR_NAME.toLowerCase())
+                .withPhone(VALID_CLIENT_PHONE)
                 .build();
         assertFalse(VALID_VENDOR.isSameContact(otherVendor));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces and different phone, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_VENDOR_NAME + " ";
-        otherVendor = new VendorBuilder(VALID_VENDOR).withName(nameWithTrailingSpaces).build();
+        otherVendor = new VendorBuilder(VALID_VENDOR)
+                .withName(nameWithTrailingSpaces)
+                .withPhone(VALID_CLIENT_PHONE)
+                .build();
         assertFalse(VALID_VENDOR.isSameContact(otherVendor));
 
         // should equal self

--- a/src/test/java/seedu/ddd/model/contact/common/ContactTest.java
+++ b/src/test/java/seedu/ddd/model/contact/common/ContactTest.java
@@ -70,20 +70,20 @@ public class ContactTest {
                 .build();
         assertFalse(VALID_CLIENT.isSameContact(otherClient));
 
-        // name differs in case and different phone, all other attributes same -> returns false
+        // name differs in case and different phone, all other attributes same -> returns true
         Contact otherVendor = new VendorBuilder(VALID_VENDOR)
                 .withName(VALID_VENDOR_NAME.toLowerCase())
                 .withPhone(VALID_CLIENT_PHONE)
                 .build();
-        assertFalse(VALID_VENDOR.isSameContact(otherVendor));
+        assertTrue(VALID_VENDOR.isSameContact(otherVendor));
 
-        // name has trailing spaces and different phone, all other attributes same -> returns false
+        // name has trailing spaces and different phone, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_VENDOR_NAME + " ";
         otherVendor = new VendorBuilder(VALID_VENDOR)
                 .withName(nameWithTrailingSpaces)
                 .withPhone(VALID_CLIENT_PHONE)
                 .build();
-        assertFalse(VALID_VENDOR.isSameContact(otherVendor));
+        assertTrue(VALID_VENDOR.isSameContact(otherVendor));
 
         // should equal self
         assertTrue(VALID_CLIENT.isSameContact(VALID_CLIENT));

--- a/src/test/java/seedu/ddd/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/ddd/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        userPrefs.setAddressBookFilePath(Paths.get("ddd.json"));
         return userPrefs;
     }
 


### PR DESCRIPTION
- [X] `isSameContact` now checks for equality in `Phone` or `Name`, instead of just `Name`, therefore contacts must not have duplicate `Name` or `Phone`
- [X] Also updated the log message to show `Dream Day Designer` instead of `AddressBook`
- [X] Storage of `Name` has been updated to disregard casing of input
- [X] json file is now named `ddd.json` instead of `addressbook.json` to align with the UG
- [X] Edit command now checks if the items displayed on the Display are `Contacts` and will throw an error if the item retrieved from the display is not a `Contact`

Closes #182
Closes #199 
Closes #202
Closes #215 