### PR TITLE
Fix consecutive special charactes not being allowed in email

### DIFF
--- a/src/main/java/seedu/ddd/model/contact/common/Address.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Address.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.ddd.commons.util.AppUtil;
 
 /**
- * Represents a Person's address in the address book.
+ * Represents a {@code Contact}'s address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
 public class Address {

--- a/src/main/java/seedu/ddd/model/contact/common/Email.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Email.java
@@ -5,26 +5,34 @@ import static java.util.Objects.requireNonNull;
 import seedu.ddd.commons.util.AppUtil;
 
 /**
- * Represents a Person's email in the address book.
+ * Represents a {@code Contact}'s email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    private static final String DISALLOW_CONSECUTIVE_DOTS = "(?!.*\\.\\.)";
+    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format LOCAL_PART@DOMAIN_NAME "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
+            + "1. The LOCAL_PART should only contain alphanumeric characters and these special characters, excluding "
+            + "the parentheses, (" + SPECIAL_CHARACTERS + ").\n"
+            + "The LOCAL_PART:\n"
+            + "    - must not start or end with any special characters\n"
+            + "    - must not contain consecutive periods (i.e. a..a)\n"
+            + "    - may contain consecutive special characters other than \".\" (i.e. a__a is allowed)."
+            + "2. This is followed by a '@' and then a DOMAIN_NAME. The DOMAIN_NAME is made up of domain labels "
             + "separated by periods.\n"
-            + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
-            + "    - have each domain label start and end with alphanumeric characters\n"
-            + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
+            + "The DOMAIN name:\n"
+            + "    - must end with a domain label at least 2 characters long\n"
+            + "    - must have each domain label start and end with alphanumeric characters\n"
+            + "    - must have each domain label consist of alphanumeric characters,"
+            + "separated only by periods or hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
+    private static final String LOCAL_PART_REGEX = "^"
+            + ALPHANUMERIC_NO_UNDERSCORE
+            + DISALLOW_CONSECUTIVE_DOTS
+            + "([" + SPECIAL_CHARACTERS + "]*"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";

--- a/src/main/java/seedu/ddd/model/contact/common/Email.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Email.java
@@ -19,7 +19,7 @@ public class Email {
             + "The LOCAL_PART:\n"
             + "    - must not start or end with any special characters\n"
             + "    - must not contain consecutive periods (i.e. a..a)\n"
-            + "    - may contain consecutive special characters other than \".\" (i.e. a__a is allowed)."
+            + "    - may contain consecutive special characters other than periods (i.e. a__a is allowed).\n"
             + "2. This is followed by a '@' and then a DOMAIN_NAME. The DOMAIN_NAME is made up of domain labels "
             + "separated by periods.\n"
             + "The DOMAIN name:\n"

--- a/src/main/java/seedu/ddd/model/contact/common/Phone.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Phone.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.ddd.commons.util.AppUtil;
 
 /**
- * Represents a Person's phone number in the address book.
+ * Represents a {@code Contact}'s phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
 public class Phone {

--- a/src/test/java/seedu/ddd/model/contact/common/EmailTest.java
+++ b/src/test/java/seedu/ddd/model/contact/common/EmailTest.java
@@ -51,6 +51,8 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("_abc@a.com")); // local part starts with special character
+        assertFalse(Email.isValidEmail("abc_@a.com")); // local part ends with special character
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
@@ -63,7 +65,10 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
-        assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("a+a@u.nus.edu")); // valid special character
+        assertTrue(Email.isValidEmail("a_a@u.nus.edu")); // valid special character
+        assertTrue(Email.isValidEmail("a+_.-a@u.nus.edu")); // multiple valid special characters
+        assertTrue(Email.isValidEmail("a____a@u.nus.edu")); // multiple valid special characters
     }
 
     @Test


### PR DESCRIPTION
## Description

Closes #200 and #201.

- [x] Modified `Email` regex to allow consecutive special characters (e.g. a__a@gmail.com, a++a@gmail.com), while disallowing consecutive periods (i.e. a..a@gmail.com)