### PR TITLE
Fix duplicateContact bug between Client and Vendor

### DIFF
--- a/src/main/java/seedu/ddd/model/contact/client/Client.java
+++ b/src/main/java/seedu/ddd/model/contact/client/Client.java
@@ -31,23 +31,6 @@ public class Client extends Contact {
         super(name, phone, email, address, tags, contactId);
     }
 
-    /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
-     */
-    @Override
-    public boolean isSameContact(Contact otherContact) {
-        if (otherContact == this) {
-            return true;
-        }
-
-        if (!(otherContact instanceof Client)) {
-            return false;
-        }
-
-        return super.isSameContact(otherContact);
-    }
-
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/ddd/model/contact/vendor/Vendor.java
+++ b/src/main/java/seedu/ddd/model/contact/vendor/Vendor.java
@@ -41,23 +41,6 @@ public class Vendor extends Contact {
         return service;
     }
 
-    /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
-     */
-    @Override
-    public boolean isSameContact(Contact otherContact) {
-        if (otherContact == this) {
-            return true;
-        }
-
-        if (!(otherContact instanceof Vendor)) {
-            return false;
-        }
-
-        return super.isSameContact(otherContact);
-    }
-
     @Override
     public boolean equals(Object other) {
         if (other == this) {


### PR DESCRIPTION
The issue was that `Client` and `Vendor` overrides the original `isSameContact` method to check if the `Contact` under comparison was the same type or not, but the check is unnecessary since we do not want there to be a contact registered both as `Client` and `Vendor`.

Closes #227 