### PR TITLE
Fix invalid input bug regarding slashes

### DIFF
--- a/src/main/java/seedu/ddd/model/contact/common/Address.java
+++ b/src/main/java/seedu/ddd/model/contact/common/Address.java
@@ -10,13 +10,14 @@ import seedu.ddd.commons.util.AppUtil;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values that does not contain \"/\", "
+            + "and it should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "^[^\s/][^/]*$";
 
     public final String value;
 

--- a/src/main/java/seedu/ddd/model/event/common/Description.java
+++ b/src/main/java/seedu/ddd/model/event/common/Description.java
@@ -8,12 +8,12 @@ import seedu.ddd.commons.util.AppUtil;
  * Represents the description of a {@code Event} in the add
  */
 public class Description {
-    public static final String MESSAGE_CONSTRAINTS =
-            "The description of a event cannot be empty.";
+    public static final String MESSAGE_CONSTRAINTS = "The description of a event can take any values that does"
+            + " not contain \"/\", and it should not be blank.";
     /*
      * Checks that there is at least one non-whitespace character
      */
-    public static final String VALIDATION_REGEX = ".*\\S.*";
+    public static final String VALIDATION_REGEX = "^[^\\s/][^/]*$";
 
     public final String description;
 

--- a/src/test/java/seedu/ddd/model/contact/common/AddressTest.java
+++ b/src/test/java/seedu/ddd/model/contact/common/AddressTest.java
@@ -27,6 +27,9 @@ public class AddressTest {
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
         assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("/")); // forward slash only
+        assertFalse(Address.isValidAddress("/Blk 123")); // starts with forward slash
+        assertFalse(Address.isValidAddress("Blk 123/456")); // forward slash in string
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));

--- a/src/test/java/seedu/ddd/model/event/common/DescriptionTest.java
+++ b/src/test/java/seedu/ddd/model/event/common/DescriptionTest.java
@@ -1,11 +1,11 @@
 package seedu.ddd.model.event.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.ddd.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
 
 public class DescriptionTest {
 
@@ -14,14 +14,21 @@ public class DescriptionTest {
         assertThrows(NullPointerException.class, () -> new Description(null));
     }
 
-    //Assumption: The null input have been filtered out.
     @Test
     public void isValidDescriptionTest() {
-        String testDescription1 = "";
-        String testDescription2 = "A normal description";
+        // null input
+        assertThrows(java.lang.IllegalArgumentException.class, () -> new Description(""));
 
-        assertThrows(java.lang.IllegalArgumentException.class, () -> new Description(testDescription1));
-        assertEquals(new Description(testDescription2).toString(), testDescription2);
+        // invalid description
+        assertFalse(Description.isValidDescription("/Wedding at the beach")); // starts with a forward slash
+        assertFalse(Description.isValidDescription("Bridal/shower event")); // contains a forward slash
+
+
+        // valid addresses
+        assertTrue(Description.isValidDescription("Wedding ceremony at church"));
+        assertTrue(Description.isValidDescription("W")); // one character
+        assertTrue(Description.isValidDescription("Romantic beachside wedding event"));
+
     }
 
     @Test


### PR DESCRIPTION
Intially, contact's address and event's description allowed for any string that was not empty. However, this resulted in the bug where users could add forward slashes within the fields, which if matches some given prefix within the command type causes incorrect parsing.

The issue has been fixed by disallowing the use of slashes within contact's address and event's description.

Closes #294