### PR TITLE
Fix typing id/one will hang the product.

### DIFF
--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -11,6 +11,7 @@ package "Parser classes"{
 Class "<<interface>>\nParser" as Parser
 Class AddressBookParser
 Class XYZCommandParser
+Class CliFlags
 Class CliSyntax
 Class ParserUtil
 Class ArgumentMultimap
@@ -31,6 +32,8 @@ XYZCommandParser ..> ArgumentTokenizer
 ArgumentTokenizer .left.> ArgumentMultimap
 XYZCommandParser ..> CliSyntax
 CliSyntax ..> Prefix
+XYZCommandParser ..>CliFlags
+CliFlags ..> Prefix
 XYZCommandParser ..> ParserUtil
 ParserUtil .down.> Prefix
 ArgumentTokenizer .down.> Prefix

--- a/src/main/java/seedu/ddd/model/contact/common/predicate/ContactPredicateBuilder.java
+++ b/src/main/java/seedu/ddd/model/contact/common/predicate/ContactPredicateBuilder.java
@@ -6,6 +6,7 @@ import static seedu.ddd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.ddd.logic.parser.ParserUtil.MESSAGE_INVALID_ID;
 import static seedu.ddd.logic.parser.ParserUtil.verifyNoEmptyInput;
 
 import java.util.Arrays;
@@ -89,6 +90,9 @@ public class ContactPredicateBuilder {
     private Predicate<Contact> addIdPredicate(ArgumentMultimap argMultimap, Predicate<Contact> combinedPredicate)
             throws ParseException {
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            if (!Id.isValidId(argMultimap.getValue(PREFIX_ID).get())) {
+                throw new ParseException(MESSAGE_INVALID_ID);
+            }
             String args = verifyNoEmptyInput(argMultimap, PREFIX_ID);
             Id contactId = new Id(Integer.parseInt(args));
             combinedPredicate = combinedPredicate.and(new ContactIdPredicate(contactId));

--- a/src/main/java/seedu/ddd/model/event/common/predicate/EventPredicateBuilder.java
+++ b/src/main/java/seedu/ddd/model/event/common/predicate/EventPredicateBuilder.java
@@ -4,6 +4,7 @@ import static seedu.ddd.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_DESC;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.ddd.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.ddd.logic.parser.ParserUtil.MESSAGE_INVALID_ID;
 import static seedu.ddd.logic.parser.ParserUtil.verifyNoEmptyInput;
 
 import java.util.Arrays;
@@ -56,6 +57,9 @@ public class EventPredicateBuilder {
     private Predicate<Event> addIdPredicate(ArgumentMultimap argMultimap, Predicate<Event> combinedPredicate)
             throws ParseException {
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
+            if (!Id.isValidId(argMultimap.getValue(PREFIX_ID).get())) {
+                throw new ParseException(MESSAGE_INVALID_ID);
+            }
             String args = verifyNoEmptyInput(argMultimap, PREFIX_ID);
             Id eventId = new Id(args);
             combinedPredicate = combinedPredicate.and(new EventIdPredicate(eventId));

--- a/src/test/java/seedu/ddd/model/contact/common/predicate/ContactPredicateBuilderTest.java
+++ b/src/test/java/seedu/ddd/model/contact/common/predicate/ContactPredicateBuilderTest.java
@@ -138,6 +138,17 @@ public class ContactPredicateBuilderTest {
         argMultimap.put(PREFIX_ID, "1");
         assertFalse(predicateBuilder.build().test(new ClientBuilder().withId(2).build()));
     }
+    @Test
+    public void testArgumentMultimap_doesNotContainValidId_throwsParseException() throws ParseException {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_ID, "two");
+        ContactPredicateBuilder predicateBuilder = new ContactPredicateBuilder(argMultimap);
+
+        assertThrows(ParseException.class, predicateBuilder::build);
+
+        argMultimap.put(PREFIX_ID, "one");
+        assertThrows(ParseException.class, predicateBuilder::build);
+    }
 
     @Test
     public void testArgumentMultimap_containsTags_returnsTrue() throws ParseException {

--- a/src/test/java/seedu/ddd/model/event/common/predicate/EventPredicateBuilderTest.java
+++ b/src/test/java/seedu/ddd/model/event/common/predicate/EventPredicateBuilderTest.java
@@ -115,6 +115,17 @@ public class EventPredicateBuilderTest {
         assertFalse(predicateBuilder.build().test(new EventBuilder().withEventId(2).build()));
     }
     @Test
+    public void testArgumentMultimap_doesNotContainValidId_throwsParseException() throws ParseException {
+        ArgumentMultimap argMultimap = new ArgumentMultimap();
+        argMultimap.put(PREFIX_ID, "two");
+        EventPredicateBuilder predicateBuilder = new EventPredicateBuilder(argMultimap);
+
+        assertThrows(ParseException.class, predicateBuilder::build);
+
+        argMultimap.put(PREFIX_ID, "one");
+        assertThrows(ParseException.class, predicateBuilder::build);
+    }
+    @Test
     public void testArgumentMultimap_containsDate_returnsTrue() throws ParseException {
         // Three same date inputs with different formats
 


### PR DESCRIPTION
Fixes #258 
Update `list` command parser to not accept any characters but instead only take in numbers.

Also updated the parser UML diagram by adding CliFlag dependencies.